### PR TITLE
Add aria-expand attribute to Popover

### DIFF
--- a/src/components/Popover.jsx
+++ b/src/components/Popover.jsx
@@ -154,9 +154,14 @@ export default class Popover extends Component {
       header,
     } = this.props;
 
+    const {
+      open,
+    } = this.state;
+
     return (
       <button
         type="button"
+        aria-expanded={open}
         onClick={this.handleHeaderClick}
         onKeyDown={this.handleHeaderKeyDown}
         onMouseEnter={this.handleHeaderMouseEnter}

--- a/test/specs/components/Popover.spec.jsx
+++ b/test/specs/components/Popover.spec.jsx
@@ -41,6 +41,7 @@ describe('Popover', () => {
     );
 
     this.container.querySelector('button').textContent.should.equal('Header');
+    this.container.querySelector('button').ariaExpanded.should.equal('false');
   });
 
   it('should open when mouse enters the header', function test() {
@@ -66,6 +67,7 @@ describe('Popover', () => {
     return new Promise((resolve) => {
       window.setTimeout(() => {
         this.container.querySelectorAll('span').length.should.equal(2);
+        this.container.querySelector('button').ariaExpanded.should.equal('true');
         resolve();
       }, 1000);
     });


### PR DESCRIPTION
**What does this do?**
* Adds aria-expanded attribute to Popover
* Add checks to Popover test that aria-expanded is set correctly

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1344

The wcag audit revealed that the aria-expanded attribute wasn't being set when using the Popover element. These changes add aria-expanded to the button which the Popover is related, and uses the `open` boolean from the component state as the value.

**How should this be tested? Do these changes have associated tests?**
* Run the tests for cspace-layout to verify the updated tests pass
* Build cspace-layout
* Update cspace-ui with the cspace-layout build
* Run the devserver for cspace-ui
* Create and save a record
* Inspect the Popover element on the record (`Saved ... minutes ago`)
  * See that aria-expanded is false when the Popover is in its default state
  * See that aria-expanded is true when mousing over the Popover 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally